### PR TITLE
searender now compiles

### DIFF
--- a/searender/Makefile
+++ b/searender/Makefile
@@ -1,12 +1,12 @@
-CFLAGS=-std=c99
+CFLAGS=-std=c99 -Wall
 
 all: s57toosm searender
 
 s57toosm: s57toosm.o s57obj.o s57att.o s57val.o
-	cc -o s57toosm s57toosm.o s57obj.o s57att.o s57val.o -liconv
+	cc -o s57toosm s57toosm.o s57obj.o s57att.o s57val.o -lm
   
 searender: searender.o map.o render.o rules.o s57obj.o s57att.o s57val.o
-	cc -o searender searender.o map.o render.o rules.o s57obj.o s57att.o s57val.o -liconv
+	cc -o searender searender.o map.o render.o rules.o s57obj.o s57att.o s57val.o -lm
 
 s57toosm.o: s57toosm.c map.h s57obj.h s57att.h s57val.h
 searender.o: searender.c map.h render.h rules.h s57obj.h s57att.h s57val.h
@@ -18,3 +18,6 @@ s57obj.o: s57obj.c s57obj.h
 s57att.o: s57att.c s57obj.h s57att.h
 s57val.o: s57val.c s57obj.h s57att.h s57val.h
 
+
+clean:
+	rm -f *.o s57toosm searender

--- a/searender/map.h
+++ b/searender/map.h
@@ -11,6 +11,7 @@
 #ifndef map_h
 #define map_h
 
+#define _BSD_SOURCE
 #ifndef system_h
 #define system_h
 #include <stdio.h>

--- a/searender/render.c
+++ b/searender/render.c
@@ -32,7 +32,7 @@ double minlat, minlon, maxlat, maxlon, top, xmax, ymax, mile;
 int zoom;
 int ref = 0;
 
-Item_t map = {{0,0,0,0,0,0,0,0,0,0}, NULL, NULL, NULL, EMPTY, 0, 0};
+Item_t map = {{0,0,0,0,0,0,0,0,0,0}, NULL, NULL, NULL, EMPTY, {0}, 0};
 
 Item_t *item = NULL;
 Obja_t type = 0;
@@ -459,9 +459,9 @@ void renderNotice(Item_t *item) {
       if (obj == NULL) continue;
       Atta_t add;
       int idx = 0;
-      while ((add = getAttEnum(obj, ADDMRK, idx++)) != MRK_UNKN) {
-        if ((add == MRK_LTRI) && (i == 2)) swap = true;
-        if ((add == MRK_RTRI) && (i != 2)) swap = true;
+      while ((add = getAttEnum(obj, ADDMRK, idx++)) != (Atta_t)MRK_UNKN) {
+        if ((add == (Atta_t)MRK_LTRI) && (i == 2)) swap = true;
+        if ((add == (Atta_t)MRK_RTRI) && (i != 2)) swap = true;
       }
     }
   }
@@ -472,7 +472,7 @@ void renderNotice(Item_t *item) {
     Atta_t add;
     int idx = 0;
     int top=0, bottom=0, left=0, right=0;
-    while ((add = getAttEnum(obj, ADDMRK, idx++)) != MRK_UNKN) {
+    while ((add = getAttEnum(obj, ADDMRK, idx++)) != (Atta_t)MRK_UNKN) {
       switch (add) {
         case MRK_TOPB:
           top = add;

--- a/searender/render.h
+++ b/searender/render.h
@@ -10,6 +10,11 @@
 #ifndef searender_render_h
 #define searender_render_h
 
+#define _BSD_SOURCE
+#ifndef __USE_BSD
+ #define __USE_BSD
+#endif
+#include <strings.h>
 #ifndef system_h
 #define system_h
 #include <stdio.h>

--- a/searender/rules.h
+++ b/searender/rules.h
@@ -10,6 +10,7 @@
 #ifndef searender_rules_h
 #define searender_rules_h
 
+#define _BSD_SOURCE
 #ifndef system_h
 #define system_h
 #include <stdio.h>

--- a/searender/s57val.c
+++ b/searender/s57val.c
@@ -9,6 +9,7 @@
 
 /* Conversion of S-57 ATTL & ATVL values to OSeaM attribute tag values */
 
+#include "s57val.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -16,7 +17,6 @@
 #include <iconv.h>
 #include <unistd.h>
 
-#include "s57val.h"
 
 typedef const struct {
   Enum_t atvl;
@@ -360,7 +360,7 @@ char *decodeValue(Attl_t attl, char *atvl) {
     case S: {
       size_t in = strlen(atvl);
       size_t out = 999;
-      bzero(outstr, out);
+      memset(outstr,0, out);
       char *to = outstr;
       iconv(conv, &atvl, &in, &to, &out);
       for (int i = 0; outstr[i] != 0; i++) {
@@ -435,7 +435,7 @@ char *stringValue(Val_t val) {
 }
 
 Val_t convertValue(char *val, Atta_t key) {
-  Val_t value = {0, S, 0};
+  Val_t value = {0, S, {0}};
   char *tok;
   value.key = key;
   s57key_t *valkey = &keys[value.key];

--- a/searender/s57val.h
+++ b/searender/s57val.h
@@ -11,7 +11,7 @@
 
 #ifndef S57VAL_H
 #define S57VAL_H
-
+#define _BSD_SOURCE
 #include "s57att.h"
 
 typedef int Enum_t;


### PR DESCRIPTION
Searender did not compile on Ubuntu. Now compiles with -Wall without warnings. A clean target is added.
